### PR TITLE
Fix button width responsiveness on bad path page

### DIFF
--- a/src/components/BadPath/BadPath.css
+++ b/src/components/BadPath/BadPath.css
@@ -13,6 +13,7 @@
 
 .bad-path-button {
   height: 10%;
+  min-width: 100px;
   width: 10%;
   border: 0;
   border-radius: 10px;
@@ -20,4 +21,8 @@
   color: white;
   font-size: 1.5rem;
   box-shadow: 0px 3px 10px rgba(255, 255, 255, 1);
+}
+
+.bad-path-text {
+  text-align: center;
 }


### PR DESCRIPTION
On smaller devices, the bad path page's button was shrinking smaller than the text. This fixes that, and also aligns the bad path message text to the center so it stay's consistent when shrunk